### PR TITLE
fix wrong variable assignment in rich text editor

### DIFF
--- a/primitive/RichtextAttributeFactory.js
+++ b/primitive/RichtextAttributeFactory.js
@@ -21,7 +21,7 @@ define([
                 props.plugins=attribute.plugins;
             }
             if (attribute.extraPlugins) {
-                props.plugins=attribute.extraPlugins;
+                props.extraPlugins=attribute.extraPlugins;
             }
             props.height=attribute.height;
             mixinTextboxBindings(modelHandle, props);


### PR DESCRIPTION
Attribute `extraPlugins` assign to property `plugin` by mistake.
